### PR TITLE
Get processor components from session data

### DIFF
--- a/excel_processor/managers/excel_processor_managers.py
+++ b/excel_processor/managers/excel_processor_managers.py
@@ -1,6 +1,8 @@
 import os
+from typing import Any
 from zipfile import ZipFile
 
+from django.urls import resolve
 import pandas as pd
 from django.http import HttpResponse, HttpResponseRedirect
 from file_upload.managers.file_upload_manager import FileUploadManagerABC
@@ -8,7 +10,6 @@ from file_upload.managers.file_upload_registry_manager import (
     FileUploadRegistryManagerABC,
 )
 from file_upload.models import FileUploadRegistryHubABC
-from mt_tools.excel_processor.forms import ExcelProcessorUploadFileForm
 from mt_tools.excel_processor.modules.excel_processor_formatter import (
     ExcelProcessorMontrekFormatter,
 )
@@ -27,40 +28,38 @@ class ExcelProcessor:
     def __init__(
         self,
         file_upload_registry_hub: FileUploadRegistryHubABC,
-        session_data: dict[str, ...],
-        upload_form: ExcelProcessorUploadFileForm,
-        request,
+        session_data: dict[str, Any],
         **kwargs,
     ):
         self.message = "Not processed!"
-        self.processor_function = upload_form.cleaned_data.get("function")
+        self.session_data = session_data
+        view_class = resolve(self.session_data["request_path"]).func.view_class
         self.excel_processor_functions_class = (
-            upload_form.excel_processor_functions_class
+            view_class.excel_processor_functions_class
         )
-        self.request = request
+        self.processor_function_name = self.session_data["function"][0]
         self.http_response = HttpResponse()
 
     def pre_check(self, file_path: str) -> bool:
         return True
 
     def process(self, file_path: str) -> bool:
-        process_function = getattr(
-            self.excel_processor_functions_class, self.processor_function
+        processor_function = getattr(
+            self.excel_processor_functions_class,
+            self.processor_function_name,
         )
         try:
-            output = process_function(file_path)
+            output = processor_function(file_path)
         except Exception as e:
-            self.message = f"Error raised during Excel File Processing function {self.processor_function}: {e}"
-            self.http_response = HttpResponseRedirect(
-                self.request.META.get("HTTP_REFERER")
-            )
+            self.message = f"Error raised during Excel File Processing function {self.processor_function_name}: {e}"
+            self.http_response = HttpResponseRedirect(self.session_data["http_referer"])
             return False
         if output.return_type == ExcelProcessorReturnType.XLSX:
             self.return_excel(output)
         elif output.return_type == ExcelProcessorReturnType.ZIP:
             self.return_zip(output)
         self._download(output, file_path)
-        self.message = f"Processed and downloaded {self.processor_function}"
+        self.message = f"Processed and downloaded {self.processor_function_name}!"
         return True
 
     def post_check(self, file_path: str) -> bool:
@@ -84,7 +83,7 @@ class ExcelProcessor:
     def _get_filename(
         self, return_type: ExcelProcessorReturnType, file_path: str
     ) -> str:
-        return f"{file_path.split('/')[-1].split('.')[0]}__{self.processor_function}.{return_type.value}"
+        return f"{file_path.split('/')[-1].split('.')[0]}__{self.processor_function_name}.{return_type.value}"
 
     def _download(self, output: ExcelProcessorReturn, file_path: str) -> None:
         application_map = {
@@ -92,9 +91,9 @@ class ExcelProcessor:
             ExcelProcessorReturnType.ZIP: "zip",
         }
         filename = self._get_filename(output.return_type, file_path)
-        self.http_response[
-            "Content-Type"
-        ] = f"application/{application_map[output.return_type]}"
+        self.http_response["Content-Type"] = (
+            f"application/{application_map[output.return_type]}"
+        )
         self.http_response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
 
@@ -106,3 +105,4 @@ class ExcelProcessorRegistryManager(FileUploadRegistryManagerABC):
 class ExcelProcessorManager(FileUploadManagerABC):
     file_upload_processor_class = ExcelProcessor
     file_registry_manager_class = ExcelProcessorRegistryManager
+    do_process_file_async = False


### PR DESCRIPTION
https://github.com/montrek-software/montrek/pull/582 makes the file upload view initialise the the file upload manager only with `session_data`. This is the case, because the optional background processing means we have to be able to initialise the processor only from serialisable data (since this may be done in the celery worker). 

Therefore, I change the excel processor initialisation slightly in this PR. Such that the processor function class is retrieved from the view from which the request originally came. The function name is passed with the session data.