### PR TITLE
Feature: Allow .TOML file uploads in ExcelProcessorUploadFileView

### DIFF
--- a/excel_processor/views.py
+++ b/excel_processor/views.py
@@ -23,7 +23,7 @@ from mt_tools.excel_processor.pages import ExcelProcessorPage
 
 class ExcelProcessorUploadFileView(MontrekUploadFileView):
     file_upload_manager_class = ExcelProcessorManager
-    accept = ".XLSX, .TOML"
+    accept = ".XLSX,.TOML"
     title = "Excel Processor"
     page_class = ExcelProcessorPage
     tab = "tab_excel_processor_upload"

--- a/excel_processor/views.py
+++ b/excel_processor/views.py
@@ -23,7 +23,7 @@ from mt_tools.excel_processor.pages import ExcelProcessorPage
 
 class ExcelProcessorUploadFileView(MontrekUploadFileView):
     file_upload_manager_class = ExcelProcessorManager
-    accept = ".XLSX"
+    accept = ".XLSX, .TOML"
     title = "Excel Processor"
     page_class = ExcelProcessorPage
     tab = "tab_excel_processor_upload"


### PR DESCRIPTION
Allow .TOML file uploads for e.g. SharePoint-based imports from a parsed config file. Functionality is necessary for Effectual workflow. If adjustments need to be made to the logic, please let me know.

file_upload views already allows multiple file types and separates them between commas. Tests showed no errors.