### PR TITLE
Feature: Add optional custom path for settings retrieval

### DIFF
--- a/excel_processor/modules/excel_processor_settings.py
+++ b/excel_processor/modules/excel_processor_settings.py
@@ -27,12 +27,18 @@ def get_excel_processor_settings(
     """Return all available TOML settings files for the given functions class.
 
     Settings files are expected in a ``settings/`` subfolder next to the
-    module that defines *functions_class*.
+    module that defines *functions_class*, or in the path specified by
+    ``settings_path`` variable, if specified.
     """
     if not functions_class.has_settings:
         return []
-    class_file = Path(inspect.getfile(functions_class))
-    settings_folder = class_file.parent / "settings"
+
+    if hasattr(functions_class, 'settings_path') and functions_class.settings_path:
+        settings_folder = Path(functions_class.settings_path)
+    else:
+        class_file = Path(inspect.getfile(functions_class))
+        settings_folder = class_file.parent / "settings"
+
     settings_folder.mkdir(exist_ok=True)
     toml_files = list(settings_folder.glob("*.toml"))
     if not toml_files:


### PR DESCRIPTION
Description:
Currently, the Excel Processor imports settings from a pre-defined path. This path however, may not always be in the most optimal position. Reworked the import functionality to check for a `settings_path` class attribute. If available, use it, if not, fall back to the default.